### PR TITLE
Update url from dahlia/libsass-python => sass/libsass-python

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,8 +27,8 @@ Tests
   AppVeyor_ (Windows).
 
 .. _tox:  http://tox.testrun.org/
-.. _Travis: http://travis-ci.org/dahlia/libsass-python
-.. _AppVeyor: https://ci.appveyor.com/project/dahlia/libsass-python
+.. _Travis: http://travis-ci.org/sass/libsass-python
+.. _AppVeyor: https://ci.appveyor.com/project/asottile/libsass-python
 
 
 Maintainer's guide
@@ -62,7 +62,7 @@ Here's a brief check list for releasing a new version:
   It's currently a static website deployed on GitHub Pages.
   Use ``python setup.py upload_doc`` command.
   Although it seems possible to be automated using Travis.
-- Manually create a release through https://github.com/dahlia/libsass-python/releases/
+- Manually create a release through https://github.com/sass/libsass-python/releases/
 
 Ping Hong Minhee (hongminhee@member.fsf.org, @dahlia on GitHub) if you need
 any help!

--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,16 @@ libsass-python: Sass_/SCSS for Python
    :alt: PyPI
    :target: https://pypi.python.org/pypi/libsass
 
-.. image:: https://travis-ci.org/dahlia/libsass-python.svg
-   :target: https://travis-ci.org/dahlia/libsass-python
+.. image:: https://travis-ci.org/sass/libsass-python.svg
+   :target: https://travis-ci.org/sass/libsass-python
    :alt: Build Status
 
-.. image:: https://ci.appveyor.com/api/projects/status/yghrs9jw7b67c0ia/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/dahlia/libsass-python
+.. image:: https://ci.appveyor.com/api/projects/status/asgquaxlffnuryoq/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/asottile/libsass-python
    :alt: Build Status (Windows)
 
-.. image:: https://coveralls.io/repos/github/dahlia/libsass-python/badge.svg?branch=master
-   :target: https://coveralls.io/github/dahlia/libsass-python?branch=master
+.. image:: https://coveralls.io/repos/github/sass/libsass-python/badge.svg?branch=master
+   :target: https://coveralls.io/github/sass/libsass-python?branch=master
    :alt: Coverage Status
 
 This package provides a simple Python extension module ``sass`` which is

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,9 +257,9 @@ intersphinx_mapping = {
 
 
 extlinks = {
-    'issue': ('https://github.com/dahlia/libsass-python/issues/%s', '#'),
-    'branch': ('https://github.com/dahlia/libsass-python/compare/master...%s',
+    'issue': ('https://github.com/sass/libsass-python/issues/%s', '#'),
+    'branch': ('https://github.com/sass/libsass-python/compare/master...%s',
                ''),
-    'commit': ('https://github.com/dahlia/libsass-python/commit/%s', ''),
+    'commit': ('https://github.com/sass/libsass-python/commit/%s', ''),
     'upcommit': ('https://github.com/sass/libsass/commit/%s', ''),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,27 +130,27 @@ Open source
 -----------
 
 GitHub (Git repository + issues)
-   https://github.com/dahlia/libsass-python
+   https://github.com/sass/libsass-python
 
 Travis CI
-   https://travis-ci.org/dahlia/libsass-python
+   https://travis-ci.org/sass/libsass-python
 
-   .. image:: https://travis-ci.org/dahlia/libsass-python.svg
-      :target: https://travis-ci.org/dahlia/libsass-python
+   .. image:: https://travis-ci.org/sass/libsass-python.svg
+      :target: https://travis-ci.org/sass/libsass-python
       :alt: Build Status
 
 AppVeyor (CI for Windows)
-   https://ci.appveyor.com/project/dahlia/libsass-python
+   https://ci.appveyor.com/project/asottile/libsass-python
 
-   .. image:: https://ci.appveyor.com/api/projects/status/yghrs9jw7b67c0ia/branch/master?svg=true
-      :target: https://ci.appveyor.com/project/dahlia/libsass-python
+   .. image:: https://ci.appveyor.com/api/projects/status/asgquaxlffnuryoq/branch/master?svg=true
+      :target: https://ci.appveyor.com/project/asottile/libsass-python
       :alt: Build Status (Windows)
 
 Coveralls (Test coverage)
-   https://coveralls.io/r/dahlia/libsass-python
+   https://coveralls.io/r/sass/libsass-python
 
-   .. image:: https://img.shields.io/coveralls/dahlia/libsass-python/master.svg
-      :target: https://coveralls.io/r/dahlia/libsass-python
+   .. image:: https://coveralls.io/repos/github/sass/libsass-python/badge.svg?branch=master
+      :target: https://coveralls.io/r/sass/libsass-python
       :alt: Coverage Status
 
 PyPI

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ class upload_doc(distutils.cmd.Command):
                              'build', 'sphinx', 'html')
         os.chdir(path)
         os.system('git clone -b gh-pages --depth 5 '
-                  'git@github.com:dahlia/libsass-python.git .')
+                  'git@github.com:sass/libsass-python.git .')
         os.system('git rm -r .')
         os.system('touch .nojekyll')
         os.system('cp -r ' + build + '/* .')
@@ -257,7 +257,7 @@ setup(
     author='Hong Minhee',
     author_email='minhee' '@' 'dahlia.kr',
     url='http://hongminhee.org/libsass-python/',
-    download_url='https://github.com/dahlia/libsass-python/releases',
+    download_url='https://github.com/sass/libsass-python/releases',
     entry_points={
         'distutils.commands': [
             'build_sass = sassutils.distutils:build_sass'

--- a/upload_appveyor_builds.py
+++ b/upload_appveyor_builds.py
@@ -17,7 +17,7 @@ from twine.commands import upload
 
 APPVEYOR_API_BASE_URL = 'https://ci.appveyor.com/api/'
 APPVEYOR_API_PROJECT_URL = urljoin(APPVEYOR_API_BASE_URL,
-                                   'projects/dahlia/libsass-python/')
+                                   'projects/asottile/libsass-python/')
 APPVEYOR_API_BUILDS_URL = urljoin(APPVEYOR_API_PROJECT_URL,
                                   'history?recordsNumber=50&branch=master')
 APPVEYOR_API_JOBS_URL = urljoin(APPVEYOR_API_PROJECT_URL,


### PR DESCRIPTION
See #229 

I think this mostly handles the urls that changed -- I think ci things are still at the old url? (I guess we'll find out!).