### PR TITLE
upload_doc must be run with python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,8 @@ class upload_doc(distutils.cmd.Command):
     user_options = []
 
     def initialize_options(self):
-        pass
+        if sys.version_info < (3,):
+            raise SystemExit('upload_doc must be run with python 3')
 
     def finalize_options(self):
         pass


### PR DESCRIPTION
The docs have some non-ideal output when run with python2.  Here's an example commit which reruns as python3 (demonstrating the differences):

https://github.com/sass/libsass-python/commit/e756ae7a163d3e8409f0722f206be07ec3ab07e9