### PR TITLE
Honor strip_extension option when building entire directory structures from distutils

### DIFF
--- a/sasstests.py
+++ b/sasstests.py
@@ -635,7 +635,7 @@ class ManifestTestCase(BaseTestCase):
             )
 
 
-def test_manifest_strip_extension(tmpdir):
+def test_manifest_build_one_strip_extension(tmpdir):
     src = tmpdir.join('test').ensure_dir()
     src.join('a.scss').write('a{b: c;}')
 
@@ -643,6 +643,16 @@ def test_manifest_strip_extension(tmpdir):
     m.build_one(str(tmpdir), 'a.scss')
 
     assert tmpdir.join('css/a.css').read() == 'a {\n  b: c; }\n'
+
+
+def test_manifest_build_strip_extension(tmpdir):
+    src = tmpdir.join('test').ensure_dir()
+    src.join('x.scss').write('a{b: c;}')
+
+    m = Manifest(sass_path='test', css_path='css', strip_extension=True)
+    m.build(package_dir=str(tmpdir))
+
+    assert tmpdir.join('css/x.css').read() == 'a {\n  b: c; }\n'
 
 
 class WsgiTestCase(BaseTestCase):

--- a/sassutils/builder.py
+++ b/sassutils/builder.py
@@ -27,7 +27,7 @@ SUFFIX_PATTERN = re.compile('[.](' + '|'.join(map(re.escape, SUFFIXES)) + ')$')
 
 
 def build_directory(sass_path, css_path, output_style='nested',
-                    _root_sass=None, _root_css=None):
+                    _root_sass=None, _root_css=None, strip_extension=False):
     """Compiles all Sass/SCSS files in ``path`` to CSS.
 
     :param sass_path: the path of the directory which contains source files
@@ -58,6 +58,8 @@ def build_directory(sass_path, css_path, output_style='nested',
             if name[0] == '_':
                 # Do not compile if it's partial
                 continue
+            if strip_extension:
+                name, _ = os.path.splitext(name)
             css_fullname = os.path.join(css_path, name) + '.css'
             css = compile(filename=sass_fullname,
                           output_style=output_style,
@@ -73,7 +75,8 @@ def build_directory(sass_path, css_path, output_style='nested',
             subresult = build_directory(sass_fullname, css_fullname,
                                         output_style=output_style,
                                         _root_sass=_root_sass,
-                                        _root_css=_root_css)
+                                        _root_css=_root_css,
+                                        strip_extension=strip_extension)
             result.update(subresult)
     return result
 
@@ -201,7 +204,8 @@ class Manifest(object):
         css_path = os.path.join(package_dir, self.css_path)
         css_files = build_directory(
             sass_path, css_path,
-            output_style=output_style
+            output_style=output_style,
+            strip_extension=self.strip_extension
         ).values()
         return frozenset(os.path.join(self.css_path, filename)
                          for filename in css_files)


### PR DESCRIPTION
Well rested from my vacation, I was planning to look at a fix for #55, as discussed in #215. Then I was pleasantly surprised to find that #258 fixed it while I was away, and that #215 now could be closed :-)

However, I did not find #258 to work at all. The `build_sass` build command invokes `Manifest.build()`, which in turn invokes the `build_directory()` function to compile an entire directory structures of SASS files. #258 only patches and tests the `Manifest.build_one()` method, which is apparently never invoked by `build_sass`.

This PR attempts to remedy that.
