### PR TITLE
Fix distutils bdist crash

### DIFF
--- a/sassutils/distutils.py
+++ b/sassutils/distutils.py
@@ -138,7 +138,12 @@ class build_sass(Command):
             )
             map(distutils.log.info, css_files)
             package_data.setdefault(package_name, []).extend(css_files)
-            data_files.extend((package_dir, f) for f in css_files)
+            data_files.append(
+                (
+                    package_dir,
+                    [os.path.join(package_dir, f) for f in css_files],
+                ),
+            )
         self.distribution.package_data = package_data
         self.distribution.data_files = data_files
         self.distribution.has_data_files = lambda: True


### PR DESCRIPTION
The `build_sass` command adds the list of compiled css files to the distribution's `data_files` attribute.

However, it does not add entries that are according to distutils' spec. This causes commands like `python setup.py bdist` or `pip install` to crash.

According to the docs, an entry in `data_files` should either be a single string, or a two-tuple of `(dir_name, [list_of_files])`. The existing code instead adds two-tuples of `(dir_name, file_name)` for each file, causing distutils to attempt to iterate over the characters of the `file_name` string and crash when it attempts to copy a non-existent, one-character-named file.

I'm not entirely sure how to write an effective test for this (and there doesn't seem to be an existing one to cover this code path).

An example of a typical traceback from running `bdist` with then environment variable `DISTUTILS_DEBUG=1`:

```pytb
running install_data
Distribution.get_command_obj(): creating 'install_data' command object
Traceback (most recent call last):
  File "setup.py", line 64, in <module>
    zip_safe=False,
  File "/source/fjas/local/lib/python2.7/site-packages/setuptools/__init__.py", line 140, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/bdist.py", line 146, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/bdist_dumb.py", line 94, in run
    self.run_command('install')
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/source/fjas/local/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
    return orig.install.run(self)
  File "/usr/lib/python2.7/distutils/command/install.py", line 613, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/install_data.py", line 74, in run
    (out, _) = self.copy_file(data, dir)
  File "/usr/lib/python2.7/distutils/cmd.py", line 365, in copy_file
    dry_run=self.dry_run)
  File "/usr/lib/python2.7/distutils/file_util.py", line 110, in copy_file
    "can't copy '%s': doesn't exist or not a regular file" % src)
distutils.errors.DistutilsFileError: can't copy 's': doesn't exist or not a regular file
```