### PR TITLE
Add more cli opts and source map config args

### DIFF
--- a/pysassc.py
+++ b/pysassc.py
@@ -47,6 +47,36 @@ There are options as well:
 
    .. versionadded:: 0.11.0
 
+.. option:: --sourcemap-file
+
+   Output file for source map
+
+   .. versionadded:: 0.17.0
+
+.. option:: --sourcemap-contents
+
+   Embed sourcesContent in source map.
+
+   .. versionadded:: 0.17.0
+
+.. option:: --sourcemap-embed
+
+   Embed sourceMappingUrl as data URI
+
+   .. versionadded:: 0.17.0
+
+.. option:: --omit-sourcemap-url
+
+   Omit source map URL comment from output
+
+   .. versionadded:: 0.17.0
+
+.. option:: --sourcemap-root
+
+   Base path, will be emitted to sourceRoot in source-map as is
+
+   .. versionadded:: 0.17.0
+
 .. option:: -v, --version
 
    Prints the program version.
@@ -91,6 +121,32 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
         action='store_true', default=False,
         help='Emit source map.  Requires the second argument '
              '(output css filename).',
+    )
+    parser.add_option(
+        '--sourcemap-file', dest='source_map_file', metavar='FILE',
+        action='store',
+        help='Output file for source map. If omitted, source map is based on '
+             'the output css filename',
+    )
+    parser.add_option(
+        '--sourcemap-contents', dest='source_map_contents',
+        action='store_true', default=False,
+        help='Embed sourcesContent in source map',
+    )
+    parser.add_option(
+        '--sourcemap-embed', dest='source_map_embed',
+        action='store_true', default=False,
+        help='Embed sourceMappingUrl as data URI',
+    )
+    parser.add_option(
+        '--omit-sourcemap-url', dest='omit_source_map_url',
+        action='store_true', default=False,
+        help='Omit source map URL comment from output',
+    )
+    parser.add_option(
+        '--sourcemap-root', metavar='DIR',
+        dest='source_map_root', action='store',
+        help='Base path, will be emitted to sourceRoot in source-map as is',
     )
     parser.add_option(
         '-I', '--include-path', metavar='DIR',
@@ -139,12 +195,16 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
 
     try:
         if options.source_map:
-            source_map_filename = args[1] + '.map'  # FIXME
+            source_map_filename = options.source_map_file or args[1] + '.map'
             css, source_map = sass.compile(
                 filename=filename,
                 output_style=options.style,
                 source_comments=options.source_comments,
                 source_map_filename=source_map_filename,
+                source_map_contents=options.source_map_contents,
+                source_map_embed=options.source_map_embed,
+                omit_source_map_url=options.omit_source_map_url,
+                source_map_root=options.source_map_root,
                 output_filename_hint=args[1],
                 include_paths=options.include_paths,
                 precision=options.precision,

--- a/sass.py
+++ b/sass.py
@@ -225,7 +225,8 @@ def _raise(e):
 
 def compile_dirname(
     search_path, output_path, output_style, source_comments, include_paths,
-    precision, custom_functions, importers,
+    precision, custom_functions, importers, source_map_contents,
+    source_map_embed, omit_source_map_url, source_map_root,
 ):
     fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
     for dirpath, _, filenames in os.walk(search_path, onerror=_raise):
@@ -243,6 +244,8 @@ def compile_dirname(
             s, v, _ = _sass.compile_filename(
                 input_filename, output_style, source_comments, include_paths,
                 precision, None, custom_functions, importers, None,
+                source_map_contents, source_map_embed, omit_source_map_url,
+                source_map_root,
             )
             if s:
                 v = v.decode('UTF-8')
@@ -284,6 +287,14 @@ def compile(**kwargs):
     :param source_comments: whether to add comments about source lines.
                             :const:`False` by default
     :type source_comments: :class:`bool`
+    :param source_map_contents: embed include contents in map
+    :type source_map_contents: :class:`bool`
+    :param source_map_embed: embed sourceMappingUrl as data URI
+    :type source_map_embed: :class:`bool`
+    :param omit_source_map_url: omit source map URL comment from output
+    :type omit_source_map_url: :class:`bool`
+    :param source_map_root: base path, will be emitted in source map as is
+    :type source_map_root: :class:`str`
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           Sass/CSS source files
     :type include_paths: :class:`collections.abc.Sequence`
@@ -325,6 +336,14 @@ def compile(**kwargs):
                                 output filename.  :const:`None` means not
                                 using source maps.  :const:`None` by default.
     :type source_map_filename: :class:`str`
+    :param source_map_contents: embed include contents in map
+    :type source_map_contents: :class:`bool`
+    :param source_map_embed: embed sourceMappingUrl as data URI
+    :type source_map_embed: :class:`bool`
+    :param omit_source_map_url: omit source map URL comment from output
+    :type omit_source_map_url: :class:`bool`
+    :param source_map_root: base path, will be emitted in source map as is
+    :type source_map_root: :class:`str`
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           Sass/CSS source files
     :type include_paths: :class:`collections.abc.Sequence`
@@ -368,6 +387,14 @@ def compile(**kwargs):
     :param source_comments: whether to add comments about source lines.
                             :const:`False` by default
     :type source_comments: :class:`bool`
+    :param source_map_contents: embed include contents in map
+    :type source_map_contents: :class:`bool`
+    :param source_map_embed: embed sourceMappingUrl as data URI
+    :type source_map_embed: :class:`bool`
+    :param omit_source_map_url: omit source map URL comment from output
+    :type omit_source_map_url: :class:`bool`
+    :param source_map_root: base path, will be emitted in source map as is
+    :type source_map_root: :class:`str`
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           Sass/CSS source files
     :type include_paths: :class:`collections.abc.Sequence`
@@ -499,6 +526,10 @@ def compile(**kwargs):
     .. versionadded:: 0.11.0
        ``source_map_filename`` no longer implies ``source_comments``.
 
+    .. versionadded:: 0.17.0
+       Added ``source_map_contents``, ``source_map_embed``,
+       ``omit_source_map_url``, and ``source_map_root`` parameters.
+
     """
     modes = set()
     for mode_name in MODES:
@@ -568,6 +599,14 @@ def compile(**kwargs):
     source_map_filename = _get_file_arg('source_map_filename')
     output_filename_hint = _get_file_arg('output_filename_hint')
 
+    source_map_contents = kwargs.pop('source_map_contents', False)
+    source_map_embed = kwargs.pop('source_map_embed', False)
+    omit_source_map_url = kwargs.pop('omit_source_map_url', False)
+    source_map_root = kwargs.pop('source_map_root', None)
+
+    if isinstance(source_map_root, text_type):
+        source_map_root = source_map_root.encode('utf-8')
+
     # #208: cwd is always included in include paths
     include_paths = (os.getcwd(),)
     include_paths += tuple(kwargs.pop('include_paths', ()) or ())
@@ -620,6 +659,8 @@ def compile(**kwargs):
         s, v = _sass.compile_string(
             string, output_style, source_comments, include_paths, precision,
             custom_functions, indented, importers,
+            source_map_contents, source_map_embed, omit_source_map_url,
+            source_map_root,
         )
         if s:
             return v.decode('utf-8')
@@ -636,6 +677,8 @@ def compile(**kwargs):
             filename, output_style, source_comments, include_paths, precision,
             source_map_filename, custom_functions, importers,
             output_filename_hint,
+            source_map_contents, source_map_embed, omit_source_map_url,
+            source_map_root,
         )
         if s:
             v = v.decode('utf-8')
@@ -655,6 +698,8 @@ def compile(**kwargs):
         s, v = compile_dirname(
             search_path, output_path, output_style, source_comments,
             include_paths, precision, custom_functions, importers,
+            source_map_contents, source_map_embed, omit_source_map_url,
+            source_map_root,
         )
         if s:
             return

--- a/test/h.sass
+++ b/test/h.sass
@@ -1,0 +1,3 @@
+a
+  b
+    color: blue


### PR DESCRIPTION
I had the need to be able to emit source maps using libsass-python that contain `sourcesContent`. When I set out to make a PR to add this functionality I realized that there are quite a few libsass options not exposed through the API, and also that the cli script does not allow setting all of the options that _are_ already exposed. With these PR, the library and cli script are brought into feature parity with other libsass bindings, such as node-sass.

Newly added kwargs include:

- `source_map_contents`: Emits `sourcesContent` property in source map (fixes #268)
- `source_map_embed`: Embeds sourcemap as a data uri in `sourceMappingURL` comment
- `omit_source_map_url`: Omits the source map comment from the css output file
- `source_map_root`: Sets the `sourceRoot` property in a source map

All of these are exposed via the cli using the existing naming conventions, i.e. `source_map_contents` can be enabled with `--sourcemap-contents`.

Newly added cli flags that map onto already exposed libsass options:

- `-i` / `--indented-syntax`: enables sass (not scss) parsing
- `--sourcemap-file`: Allows overriding of `source_map_filename` via the cli
