### PR TITLE
Migrate to official pycqa/flake8 hooks repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,18 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: debug-statements
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
     -   id: flake8
         exclude: ^docs/conf.py
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.8.0
+    rev: v1.11.1
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/asottile/add-trailing-comma


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos