### PR TITLE
Add support for passing previous file to importer callback

### DIFF
--- a/pysass.cpp
+++ b/pysass.cpp
@@ -423,9 +423,14 @@ static Sass_Import_List _call_py_importer_f(
     PyObject* pyfunc = (PyObject*)sass_importer_get_cookie(cb);
     PyObject* py_result = NULL;
     Sass_Import_List sass_imports = NULL;
+    struct Sass_Import* previous;
+    const char* prev_path;
     Py_ssize_t i;
 
-    py_result = PyObject_CallFunction(pyfunc, PySass_IF_PY3("y", "s"), path);
+    previous = sass_compiler_get_last_import(comp);
+    prev_path = sass_import_get_abs_path(previous);
+
+    py_result = PyObject_CallFunction(pyfunc, PySass_IF_PY3("yy", "ss"), path, prev_path);
 
     /* Handle importer throwing an exception */
     if (!py_result) goto done;

--- a/sasstests.py
+++ b/sasstests.py
@@ -341,6 +341,23 @@ a {
         )
         assert ret == 'b i{font-size:20px}.foo-one-arg{color:blue}\n'
 
+    def test_importer_prev_path(self):
+        def importer(path, prev):
+            assert path in ('a', 'b')
+            if path == 'a':
+                assert prev == 'stdin'
+                return ((path, '@import "b";'),)
+            elif path == 'b':
+                assert prev == 'a'
+                return ((path, 'a { color: red; }'),)
+
+        ret = sass.compile(
+            string='@import "a";',
+            importers=((0, importer),),
+            output_style='compressed',
+        )
+        assert ret == 'a{color:red}\n'
+
     def test_importer_does_not_handle_returns_None(self):
         def importer_one(path):
             if path == 'one':


### PR DESCRIPTION
This change adds feature-parity with node-sass importers, where callbacks are passed both the value of the import directive and the path from which the directive was made. This is particularly useful in cases where the importer needs to resolve relative paths.

I wasn't sure about the best way to go about maintaining backwards-compatibility. Here I added a conditional getargspec call in the importer callback wrapper, but I'm open to any other suggestions.