### PR TITLE
Make the build reproducible

### DIFF
--- a/sassutils/builder.py
+++ b/sassutils/builder.py
@@ -22,7 +22,9 @@ SUFFIXES = frozenset(('sass', 'scss'))
 
 #: (:class:`re.RegexObject`) The regular expression pattern which matches to
 #: filenames of supported :const:`SUFFIXES`.
-SUFFIX_PATTERN = re.compile('[.](' + '|'.join(map(re.escape, SUFFIXES)) + ')$')
+SUFFIX_PATTERN = re.compile(
+    '[.](' + '|'.join(map(re.escape, sorted(SUFFIXES))) + ')$',
+)
 
 
 def build_directory(


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that libsass-python could not be built reproducibly. This is due to the manpage containing content that is generated by iterating over a Python `frozenset` type, which is non-deterministic.

This was originally filed in Debian as [#971527](https://bugs.debian.org/971527).