### PR TITLE
Fix build issues with Clang compiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libsass"]
 path = libsass
-url = git://github.com/sass/libsass.git
+url = git@github.com:/sass/libsass.git

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import Extension, setup
 
 MACOS_FLAG = ['-mmacosx-version-min=10.7']
 FLAGS_POSIX = [
-    '-fPIC', '-std=gnu++0x', '-Wall', '-Wno-parentheses', '-Werror=switch',
+    '-fPIC', '-std=gnu++11', '-Wall', '-Wno-parentheses', '-Werror=switch',
 ]
 FLAGS_CLANG = ['-c', '-O3'] + FLAGS_POSIX + ['-stdlib=libc++']
 LFLAGS_POSIX = ['-fPIC',  '-lstdc++']


### PR DESCRIPTION
git submodule libsass was pointing to deprecated url, see https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

GCC compiler option gnu++0x is deprecated in favour of gnu++11. This eases a pain especially for those who want to build using Clang instead, as such option does not exist at all there.
From GCC manual:
gnu++11
gnu++0x
    GNU dialect of -std=c++11.  The name gnu++0x is deprecated.