### PR TITLE
Add py310 toxenv

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,5 +29,5 @@ jobs:
     wheel_tags: true
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py37, py38, py39]
+    toxenvs: [pypy3, py37, py38, py39, py310]
     os: linux


### PR DESCRIPTION
I saw asottile drop py36 in a recent livestream of his, and noticed that azure isn't testing on anything newer than py39 so I thought I'd add it in. I recall when 3.10 dropped about it sometimes being read as 3.1, but according to [this](https://github.com/tox-dev/azure-pipelines-template#parameters), just using `py310` as I have should be fine? 

Hope this helps. :) 